### PR TITLE
Enable High DPI display support.

### DIFF
--- a/lesson01/index.html
+++ b/lesson01/index.html
@@ -31,7 +31,22 @@
     var gl;
     function initGL(canvas) {
         try {
-            gl = canvas.getContext("experimental-webgl");
+            var devicePixelRatio = window.devicePixelRatio || 1;
+            var width = canvas.clientWidth;
+            var height = canvas.clientHeight;
+
+            // set the display size of the canvas.
+            canvas.style.width  = width  + "px";
+            canvas.style.height = height + "px";
+
+            // set the size of the drawingBuffer
+            canvas.width  = width  * devicePixelRatio;
+            canvas.height = height * devicePixelRatio;
+
+            gl = canvas.getContext("webgl");
+            if (gl == null) {
+                gl = canvas.getContext("experimental-webgl");
+            }
             gl.viewportWidth = canvas.width;
             gl.viewportHeight = canvas.height;
         } catch (e) {

--- a/lesson02/index.html
+++ b/lesson02/index.html
@@ -38,7 +38,22 @@
 
     function initGL(canvas) {
         try {
-            gl = canvas.getContext("experimental-webgl");
+            var devicePixelRatio = window.devicePixelRatio || 1;
+            var width = canvas.clientWidth;
+            var height = canvas.clientHeight;
+
+            // set the display size of the canvas.
+            canvas.style.width  = width  + "px";
+            canvas.style.height = height + "px";
+
+            // set the size of the drawingBuffer
+            canvas.width  = width  * devicePixelRatio;
+            canvas.height = height * devicePixelRatio;
+
+            gl = canvas.getContext("webgl");
+            if (gl == null) {
+                gl = canvas.getContext("experimental-webgl");
+            }
             gl.viewportWidth = canvas.width;
             gl.viewportHeight = canvas.height;
         } catch (e) {

--- a/lesson03/index.html
+++ b/lesson03/index.html
@@ -39,7 +39,22 @@
 
     function initGL(canvas) {
         try {
-            gl = canvas.getContext("experimental-webgl");
+            var devicePixelRatio = window.devicePixelRatio || 1;
+            var width = canvas.clientWidth;
+            var height = canvas.clientHeight;
+
+            // set the display size of the canvas.
+            canvas.style.width  = width  + "px";
+            canvas.style.height = height + "px";
+
+            // set the size of the drawingBuffer
+            canvas.width  = width  * devicePixelRatio;
+            canvas.height = height * devicePixelRatio;
+
+            gl = canvas.getContext("webgl");
+            if (gl == null) {
+                gl = canvas.getContext("experimental-webgl");
+            }
             gl.viewportWidth = canvas.width;
             gl.viewportHeight = canvas.height;
         } catch (e) {

--- a/lesson04/index.html
+++ b/lesson04/index.html
@@ -39,7 +39,22 @@
 
     function initGL(canvas) {
         try {
-            gl = canvas.getContext("experimental-webgl");
+            var devicePixelRatio = window.devicePixelRatio || 1;
+            var width = canvas.clientWidth;
+            var height = canvas.clientHeight;
+
+            // set the display size of the canvas.
+            canvas.style.width  = width  + "px";
+            canvas.style.height = height + "px";
+
+            // set the size of the drawingBuffer
+            canvas.width  = width  * devicePixelRatio;
+            canvas.height = height * devicePixelRatio;
+
+            gl = canvas.getContext("webgl");
+            if (gl == null) {
+                gl = canvas.getContext("experimental-webgl");
+            }
             gl.viewportWidth = canvas.width;
             gl.viewportHeight = canvas.height;
         } catch (e) {

--- a/lesson05/index.html
+++ b/lesson05/index.html
@@ -42,7 +42,22 @@
 
     function initGL(canvas) {
         try {
-            gl = canvas.getContext("experimental-webgl");
+            var devicePixelRatio = window.devicePixelRatio || 1;
+            var width = canvas.clientWidth;
+            var height = canvas.clientHeight;
+
+            // set the display size of the canvas.
+            canvas.style.width  = width  + "px";
+            canvas.style.height = height + "px";
+
+            // set the size of the drawingBuffer
+            canvas.width  = width  * devicePixelRatio;
+            canvas.height = height * devicePixelRatio;
+
+            gl = canvas.getContext("webgl");
+            if (gl == null) {
+                gl = canvas.getContext("experimental-webgl");
+            }
             gl.viewportWidth = canvas.width;
             gl.viewportHeight = canvas.height;
         } catch (e) {

--- a/lesson06/index.html
+++ b/lesson06/index.html
@@ -42,7 +42,22 @@
 
     function initGL(canvas) {
         try {
-            gl = canvas.getContext("experimental-webgl");
+            var devicePixelRatio = window.devicePixelRatio || 1;
+            var width = canvas.clientWidth;
+            var height = canvas.clientHeight;
+
+            // set the display size of the canvas.
+            canvas.style.width  = width  + "px";
+            canvas.style.height = height + "px";
+
+            // set the size of the drawingBuffer
+            canvas.width  = width  * devicePixelRatio;
+            canvas.height = height * devicePixelRatio;
+
+            gl = canvas.getContext("webgl");
+            if (gl == null) {
+                gl = canvas.getContext("experimental-webgl");
+            }
             gl.viewportWidth = canvas.width;
             gl.viewportHeight = canvas.height;
         } catch (e) {

--- a/lesson07/index.html
+++ b/lesson07/index.html
@@ -61,7 +61,22 @@
 
     function initGL(canvas) {
         try {
-            gl = canvas.getContext("experimental-webgl");
+            var devicePixelRatio = window.devicePixelRatio || 1;
+            var width = canvas.clientWidth;
+            var height = canvas.clientHeight;
+
+            // set the display size of the canvas.
+            canvas.style.width  = width  + "px";
+            canvas.style.height = height + "px";
+
+            // set the size of the drawingBuffer
+            canvas.width  = width  * devicePixelRatio;
+            canvas.height = height * devicePixelRatio;
+
+            gl = canvas.getContext("webgl");
+            if (gl == null) {
+                gl = canvas.getContext("experimental-webgl");
+            }
             gl.viewportWidth = canvas.width;
             gl.viewportHeight = canvas.height;
         } catch (e) {

--- a/lesson08/index.html
+++ b/lesson08/index.html
@@ -63,7 +63,22 @@
 
     function initGL(canvas) {
         try {
-            gl = canvas.getContext("experimental-webgl");
+            var devicePixelRatio = window.devicePixelRatio || 1;
+            var width = canvas.clientWidth;
+            var height = canvas.clientHeight;
+
+            // set the display size of the canvas.
+            canvas.style.width  = width  + "px";
+            canvas.style.height = height + "px";
+
+            // set the size of the drawingBuffer
+            canvas.width  = width  * devicePixelRatio;
+            canvas.height = height * devicePixelRatio;
+
+            gl = canvas.getContext("webgl");
+            if (gl == null) {
+                gl = canvas.getContext("experimental-webgl");
+            }
             gl.viewportWidth = canvas.width;
             gl.viewportHeight = canvas.height;
         } catch (e) {

--- a/lesson09/index.html
+++ b/lesson09/index.html
@@ -44,7 +44,22 @@
 
     function initGL(canvas) {
         try {
-            gl = canvas.getContext("experimental-webgl");
+            var devicePixelRatio = window.devicePixelRatio || 1;
+            var width = canvas.clientWidth;
+            var height = canvas.clientHeight;
+
+            // set the display size of the canvas.
+            canvas.style.width  = width  + "px";
+            canvas.style.height = height + "px";
+
+            // set the size of the drawingBuffer
+            canvas.width  = width  * devicePixelRatio;
+            canvas.height = height * devicePixelRatio;
+
+            gl = canvas.getContext("webgl");
+            if (gl == null) {
+                gl = canvas.getContext("experimental-webgl");
+            }
             gl.viewportWidth = canvas.width;
             gl.viewportHeight = canvas.height;
         } catch (e) {

--- a/lesson10/index.html
+++ b/lesson10/index.html
@@ -41,7 +41,22 @@
 
     function initGL(canvas) {
         try {
-            gl = canvas.getContext("experimental-webgl");
+            var devicePixelRatio = window.devicePixelRatio || 1;
+            var width = canvas.clientWidth;
+            var height = canvas.clientHeight;
+
+            // set the display size of the canvas.
+            canvas.style.width  = width  + "px";
+            canvas.style.height = height + "px";
+
+            // set the size of the drawingBuffer
+            canvas.width  = width  * devicePixelRatio;
+            canvas.height = height * devicePixelRatio;
+
+            gl = canvas.getContext("webgl");
+            if (gl == null) {
+                gl = canvas.getContext("experimental-webgl");
+            }
             gl.viewportWidth = canvas.width;
             gl.viewportHeight = canvas.height;
         } catch (e) {

--- a/lesson11/index.html
+++ b/lesson11/index.html
@@ -61,7 +61,22 @@
 
     function initGL(canvas) {
         try {
-            gl = canvas.getContext("experimental-webgl");
+            var devicePixelRatio = window.devicePixelRatio || 1;
+            var width = canvas.clientWidth;
+            var height = canvas.clientHeight;
+
+            // set the display size of the canvas.
+            canvas.style.width  = width  + "px";
+            canvas.style.height = height + "px";
+
+            // set the size of the drawingBuffer
+            canvas.width  = width  * devicePixelRatio;
+            canvas.height = height * devicePixelRatio;
+
+            gl = canvas.getContext("webgl");
+            if (gl == null) {
+                gl = canvas.getContext("experimental-webgl");
+            }
             gl.viewportWidth = canvas.width;
             gl.viewportHeight = canvas.height;
         } catch (e) {

--- a/lesson12/index.html
+++ b/lesson12/index.html
@@ -64,7 +64,22 @@
 
     function initGL(canvas) {
         try {
-            gl = canvas.getContext("experimental-webgl");
+            var devicePixelRatio = window.devicePixelRatio || 1;
+            var width = canvas.clientWidth;
+            var height = canvas.clientHeight;
+
+            // set the display size of the canvas.
+            canvas.style.width  = width  + "px";
+            canvas.style.height = height + "px";
+
+            // set the size of the drawingBuffer
+            canvas.width  = width  * devicePixelRatio;
+            canvas.height = height * devicePixelRatio;
+
+            gl = canvas.getContext("webgl");
+            if (gl == null) {
+                gl = canvas.getContext("experimental-webgl");
+            }
             gl.viewportWidth = canvas.width;
             gl.viewportHeight = canvas.height;
         } catch (e) {

--- a/lesson13/index.html
+++ b/lesson13/index.html
@@ -133,7 +133,22 @@
 
     function initGL(canvas) {
         try {
-            gl = canvas.getContext("experimental-webgl");
+            var devicePixelRatio = window.devicePixelRatio || 1;
+            var width = canvas.clientWidth;
+            var height = canvas.clientHeight;
+
+            // set the display size of the canvas.
+            canvas.style.width  = width  + "px";
+            canvas.style.height = height + "px";
+
+            // set the size of the drawingBuffer
+            canvas.width  = width  * devicePixelRatio;
+            canvas.height = height * devicePixelRatio;
+
+            gl = canvas.getContext("webgl");
+            if (gl == null) {
+                gl = canvas.getContext("experimental-webgl");
+            }
             gl.viewportWidth = canvas.width;
             gl.viewportHeight = canvas.height;
         } catch (e) {

--- a/lesson14/index.html
+++ b/lesson14/index.html
@@ -90,7 +90,22 @@
 
     function initGL(canvas) {
         try {
-            gl = canvas.getContext("experimental-webgl");
+            var devicePixelRatio = window.devicePixelRatio || 1;
+            var width = canvas.clientWidth;
+            var height = canvas.clientHeight;
+
+            // set the display size of the canvas.
+            canvas.style.width  = width  + "px";
+            canvas.style.height = height + "px";
+
+            // set the size of the drawingBuffer
+            canvas.width  = width  * devicePixelRatio;
+            canvas.height = height * devicePixelRatio;
+
+            gl = canvas.getContext("webgl");
+            if (gl == null) {
+                gl = canvas.getContext("experimental-webgl");
+            }
             gl.viewportWidth = canvas.width;
             gl.viewportHeight = canvas.height;
         } catch (e) {

--- a/lesson15/index.html
+++ b/lesson15/index.html
@@ -93,7 +93,22 @@
 
     function initGL(canvas) {
         try {
-            gl = canvas.getContext("experimental-webgl");
+            var devicePixelRatio = window.devicePixelRatio || 1;
+            var width = canvas.clientWidth;
+            var height = canvas.clientHeight;
+
+            // set the display size of the canvas.
+            canvas.style.width  = width  + "px";
+            canvas.style.height = height + "px";
+
+            // set the size of the drawingBuffer
+            canvas.width  = width  * devicePixelRatio;
+            canvas.height = height * devicePixelRatio;
+
+            gl = canvas.getContext("webgl");
+            if (gl == null) {
+                gl = canvas.getContext("experimental-webgl");
+            }
             gl.viewportWidth = canvas.width;
             gl.viewportHeight = canvas.height;
         } catch (e) {

--- a/lesson16/index.html
+++ b/lesson16/index.html
@@ -101,7 +101,22 @@
 
     function initGL(canvas) {
         try {
-            gl = canvas.getContext("experimental-webgl");
+            var devicePixelRatio = window.devicePixelRatio || 1;
+            var width = canvas.clientWidth;
+            var height = canvas.clientHeight;
+
+            // set the display size of the canvas.
+            canvas.style.width  = width  + "px";
+            canvas.style.height = height + "px";
+
+            // set the size of the drawingBuffer
+            canvas.width  = width  * devicePixelRatio;
+            canvas.height = height * devicePixelRatio;
+
+            gl = canvas.getContext("webgl");
+            if (gl == null) {
+                gl = canvas.getContext("experimental-webgl");
+            }
             gl.viewportWidth = canvas.width;
             gl.viewportHeight = canvas.height;
         } catch (e) {


### PR DESCRIPTION
These changes make the webGL context render at the native resolution
for high DPI displays like on the retina MacBook Pro and Chromebook
Pixel.

Low DPI:
![lowdpi](https://f.cloud.github.com/assets/327081/281946/177dc9fc-9184-11e2-90bd-1124adbf06e3.png)

High DPI:
![hidpi](https://f.cloud.github.com/assets/327081/281945/1776a01e-9184-11e2-8157-e9b208096bdd.png)
